### PR TITLE
Create stylesheet for widget, enqueue it, add styles for #16 and #9

### DIFF
--- a/css/dfp.css
+++ b/css/dfp.css
@@ -1,0 +1,6 @@
+.display-none {
+  display: none;
+}
+.widget_doubleclick_widget {
+  text-align: center;
+}

--- a/dfw-init.php
+++ b/dfw-init.php
@@ -122,6 +122,11 @@ class DoubleClick {
 		$this->breakpoints[$identifier] = new DoubleClickBreakpoint($identifier,$args);
 	}
 
+	/**
+	 * Register scripts
+	 *
+	 * @global WP_DEBUG used to determine whether or not 
+	 */
 	public function enqueue_scripts() {
 		$suffix = (WP_DEBUG)? '' : '.min';
 
@@ -157,6 +162,14 @@ class DoubleClick {
 
 		wp_localize_script( 'jquery.dfw.js', 'dfw', $data );
 		wp_enqueue_script( 'jquery.dfw.js' );
+
+		wp_enqueue_style(
+			'dfp',
+			plugins_url( 'css/dfp.css', __FILE__ ),
+			array(),
+			DFP_VERSION,
+			'all'
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Changes

- Adds dfp.css to the plugin. This is not minified or compiled from LESS because it's so simple and small
- Adds style to hide `.display-none` elements with `display: none;`. This class is referenced by `dfp.js`. For #16. 
- Adds style centering text within the ad widget, for #9.

## Why

For #16 and #9, and for http://jira.inn.org/browse/RNS-167