### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,4 +48,4 @@ See [Developer API](Developer-API.md) documentation.
 
 ## 3. Is that it?
 
-Nope! Next [configure targeting](targeting/) and advanced users may look at the [developer api](developer-api/).
+Nope! Next [configure targeting](targeting.md) and advanced users may look at the [developer api](developer-api/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,4 +48,4 @@ See [Developer API](Developer-API.md) documentation.
 
 ## 3. Is that it?
 
-Nope! Next [configure targeting](targeting.md) and advanced users may look at the [developer api](developer-api/).
+Nope! Next [configure targeting](Targeting.md) and advanced users may look at the [developer api](developer-api/).


### PR DESCRIPTION
## What was done

- Audited the docs for errors and missing pieces
- Found the link broken in index.md to Targeting.md
- Fixed the broken link
