### PR TITLE
Initialize empty variable $mapping for foreach

### DIFF
--- a/dfw-init.php
+++ b/dfw-init.php
@@ -378,6 +378,8 @@ class DoubleClickAdSlot {
 		if( !$this->hasMapping() )
 			return false;
 
+		$mapping = array();
+
 		foreach($this->sizes as $breakpointIdentifier=>$size) {
 			$breakpoint = $DoubleClick->breakpoints[$breakpointIdentifier];
 


### PR DESCRIPTION
This prevents a PHP warning described in #14, where if an ad had no mappings it would cause a parsing error.