### PR TITLE
Add ::before element on displayed ad units

### DIFF
--- a/css/dfp.css
+++ b/css/dfp.css
@@ -8,7 +8,6 @@
   speak: auto;
   text-transform: upper;
   content: "Advertisment";
-  color: #999;
   margin-bottom: 6px;
   display: block;
   text-align: center;

--- a/css/dfp.css
+++ b/css/dfp.css
@@ -6,7 +6,7 @@
 }
 .dfw-unit.display-block:before {
   speak: auto;
-  text-transform: upper;
+  text-transform: uppercase;
   content: "Advertisement";
   display: block;
   text-align: center;

--- a/css/dfp.css
+++ b/css/dfp.css
@@ -4,3 +4,14 @@
 .widget_doubleclick_widget {
   text-align: center;
 }
+.dfw-unit.display-block:before {
+  speak: auto;
+  text-transform: upper;
+  content: "Advertisment";
+  color: #999;
+  margin-bottom: 6px;
+  display: block;
+  text-align: center;
+  font-size: 14px;
+  color: #aaa;
+}

--- a/css/dfp.css
+++ b/css/dfp.css
@@ -7,8 +7,7 @@
 .dfw-unit.display-block:before {
   speak: auto;
   text-transform: upper;
-  content: "Advertisment";
-  margin-bottom: 6px;
+  content: "Advertisement";
   display: block;
   text-align: center;
   font-size: 14px;


### PR DESCRIPTION
## Changes

- Adds a ::before element on ad units that have a `.display-block` class (only added when creative has been fetched and is being displayed)

<img width="382" alt="screen shot 2016-09-01 at 5 01 21 pm" src="https://cloud.githubusercontent.com/assets/1754187/18184776/94f050aa-7068-11e6-8aa9-4581ca761c42.png">
<img width="405" alt="screen shot 2016-09-01 at 5 20 27 pm" src="https://cloud.githubusercontent.com/assets/1754187/18184775/94efbfa0-7068-11e6-84e2-6e3c728e5f5a.png">

It even works on headers:

<img width="792" alt="screen shot 2016-09-01 at 5 20 39 pm" src="https://cloud.githubusercontent.com/assets/1754187/18184777/94f15180-7068-11e6-8a63-8b145e3ad084.png">

Here's how big it is:

<img width="787" alt="screen shot 2016-09-01 at 5 20 51 pm" src="https://cloud.githubusercontent.com/assets/1754187/18184778/94fc9ab8-7068-11e6-88b7-cfe4371ef088.png">
