### PR TITLE
Fix invalid foreach errors

### DIFF
--- a/dfw-init.php
+++ b/dfw-init.php
@@ -380,7 +380,11 @@ class DoubleClickAdSlot {
 
 		$mapping = array();
 
-		foreach($this->sizes as $breakpointIdentifier=>$size) {
+		if ( empty( $this->sizes ) ) {
+			return $mapping;
+		}
+
+		foreach( $this->sizes as $breakpointIdentifier => $size ) {
 			$breakpoint = $DoubleClick->breakpoints[$breakpointIdentifier];
 
 			// The minimum browser width/height for this sizemapping.
@@ -390,15 +394,15 @@ class DoubleClickAdSlot {
 			$sizeStrings = explode(",",$size);	// eg. 300x250,336x300
 			$sizeArray = array();
 
-			foreach($sizeStrings as $s) {
-				if( !empty($s) ) :
+			foreach( $sizeStrings as $s ) {
+				if ( !empty( $s ) ) {
 					$arr = explode("x",$s);		// eg. 300x250
-					$w = (int)$arr[0];
-					$h = (int)$arr[1];
+					$w = (int) $arr[0];
+					$h = (int) $arr[1];
 					$sizeArray[] = array($w,$h);
-				else :
+				} else {
 					// $sizeArray[] = array();
-				endif;
+				}
 			}
 
 			$mapping[] = array(

--- a/dfw-init.php
+++ b/dfw-init.php
@@ -395,7 +395,7 @@ class DoubleClickAdSlot {
 			$sizeArray = array();
 
 			foreach( $sizeStrings as $s ) {
-				if ( !empty( $s ) ) {
+				if ( ! empty( $s ) ) {
 					$arr = explode("x",$s);		// eg. 300x250
 					$w = (int) $arr[0];
 					$h = (int) $arr[1];

--- a/dfw-options.php
+++ b/dfw-options.php
@@ -24,7 +24,7 @@ add_action( 'admin_menu', 'dfw_plugin_menu' );
 function dfw_option_page_html() {
 	// Nice try.
 	if ( !current_user_can( 'manage_options' ) )
-		wp_die( __( 'You do not have sufficient permissions to access this page.' ) );
+		wp_die( __( 'You do not have sufficient permissions to access this page.', 'dfw' ) );
 
 	echo '<div class="wrap">';
 	echo '<h2>DoubleClick for WordPress Options</h2>';

--- a/dfw-widget.php
+++ b/dfw-widget.php
@@ -33,10 +33,10 @@ class DoubleClick_Widget extends WP_Widget {
 
 		// prepare size parameter.
 		$sizes = $instance['sizes'];
-		if ( !empty( $sizes ) ) {
-			foreach($sizes as $b=>$s) {
-				if ( empty($sizes[$b]) ) {
-					unset($sizes[$b]);
+		if ( ! empty( $sizes ) ) {
+			foreach ( $sizes as $b => $s ) {
+				if ( empty( $sizes[$b] ) ) {
+					unset( $sizes[$b] );
 				}
 			}
 		} else {

--- a/dfw-widget.php
+++ b/dfw-widget.php
@@ -33,7 +33,6 @@ class DoubleClick_Widget extends WP_Widget {
 
 		// prepare size parameter.
 		$sizes = $instance['sizes'];
-		error_log(var_export( $sizes, true));
 		if ( !empty( $sizes ) ) {
 			foreach($sizes as $b=>$s) {
 				if ( empty($sizes[$b]) ) {

--- a/dfw-widget.php
+++ b/dfw-widget.php
@@ -28,19 +28,24 @@ class DoubleClick_Widget extends WP_Widget {
 
 		global $DoubleClick;
 
-		echo $args['before_widget'];
-
 		// prepare identifier parameter.
 		$identifier = ! empty( $instance['identifier'] ) ? $instance['identifier'] : 'ident';
 
 		// prepare size parameter.
 		$sizes = $instance['sizes'];
+		error_log(var_export( $sizes, true));
 		if ( !empty( $sizes ) ) {
 			foreach($sizes as $b=>$s) {
 				if ( empty($sizes[$b]) ) {
 					unset($sizes[$b]);
 				}
 			}
+		} else {
+			printf(
+				'<!-- %1$s -->',
+				__( 'This DoubleClick for WordPress widget is not appearing because the widget has no sizes set for its breakpoints.', 'dfw' )
+			);
+			return;
 		}
 
 		// bugfix: replace $args with $dfw_args to prevent widget interference
@@ -49,6 +54,9 @@ class DoubleClick_Widget extends WP_Widget {
 		if ( $instance['lazyLoad'] ) {
 			$dfw_args = array( 'lazyLoad' => true );
 		}
+
+		// begin actual widget output
+		echo $args['before_widget'];
 
 		// print (optional) title.
 		if ( ! empty( $instance['title'] ) ) {

--- a/dfw-widget.php
+++ b/dfw-widget.php
@@ -35,9 +35,11 @@ class DoubleClick_Widget extends WP_Widget {
 
 		// prepare size parameter.
 		$sizes = $instance['sizes'];
-		foreach($sizes as $b=>$s) {
-			if ( empty($sizes[$b]) ) {
-				unset($sizes[$b]);
+		if ( !empty( $sizes ) ) {
+			foreach($sizes as $b=>$s) {
+				if ( empty($sizes[$b]) ) {
+					unset($sizes[$b]);
+				}
 			}
 		}
 


### PR DESCRIPTION
## Changes

- If an ad unit has no size mappings, don't try to `foreach`.
- If a widget has no size strings, don't try to `foreach`, and, in addition, replace the widget with a HTML comment explaining why the widget does not appear.
- Add a missing text domain to a `__()` call.

## Why

For #34, when WP_DEBUG is true.