### PR TITLE
Switch to better access of static variables

### DIFF
--- a/dfw-init.php
+++ b/dfw-init.php
@@ -91,9 +91,9 @@ class DoubleClick {
 		$this->networkCode = $networkCode;
 
 		// Script enqueue is static because we only ever want to print it once.
-		if( ! self::$enqueued ) {
+		if( ! $this::$enqueued ) {
 			add_action( 'wp_footer', array( $this, 'enqueue_scripts' ) );
-			self::$enqueued = true;
+			$this::$enqueued = true;
 		}
 
 		add_action('wp_print_footer_scripts', array($this, 'footer_script'));

--- a/dfw-init.php
+++ b/dfw-init.php
@@ -91,9 +91,9 @@ class DoubleClick {
 		$this->networkCode = $networkCode;
 
 		// Script enqueue is static because we only ever want to print it once.
-		if(!$this::$enqueued) {
-			add_action('wp_footer', array($this, 'enqueue_scripts'));
-			$this->enqueued = true;
+		if( ! self::$enqueued ) {
+			add_action( 'wp_footer', array( $this, 'enqueue_scripts' ) );
+			self::$enqueued = true;
 		}
 
 		add_action('wp_print_footer_scripts', array($this, 'footer_script'));


### PR DESCRIPTION
## Changes

- Changes from `->` to `::` for setting whether this thing is enqueued.

## Why

For #37.

Because 